### PR TITLE
refactor: cleanup

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "faceit-stats-widget",
   "private": true,
-  "version": "3.2.1",
+  "version": "3.2.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,7 +2,9 @@ import {BrowserRouter} from "react-router-dom";
 import {Generator} from "./generator/Generator.tsx";
 import './styles/app.less'
 import ReactDOM from "react-dom/client";
+import {createContext} from "react";
 
+export const LanguageContext = createContext(null)
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <BrowserRouter>
     <Generator/>

--- a/src/generator/Generator.tsx
+++ b/src/generator/Generator.tsx
@@ -236,20 +236,7 @@ export const Generator = () => {
       <section className={'preview'}>
         <Separator text={tl(language, 'generator.preview.title')}/>
         <div className={`${theme}-theme ${colorScheme}-scheme preview`}>
-          <Widget preview={true} overrideShowEloDiff={showEloDiff} overrideShowEloSuffix={showEloSuffix}
-                  overrideShowUsername={showUsername}
-                  overrideRankingState={showRanking}
-                  overrideShowStatistics={showStatistics}
-                  overrideShowEloProgressBar={showEloProgressBar}
-                  overrideUsername={username.length > 0 ? username : "Player"}
-                  overrideCustomCSS={customCSS} overrideCustomScheme={colorScheme === "custom"}
-                  overrideLanguage={language.id}
-                  overrideBorder1={customBorderColor1} overrideBorder2={customBorderColor2}
-                  overrideTextColor={customTextColor} overrideBackground={customBackgroundColor}
-                  overrideUseBannerAsBackground={useBannerAsBackground}
-                  overrideStatistics={[statSlot1, statSlot2, statSlot3, statSlot4]}
-                  overrideBackgroundOpacity={useBannerAsBackground && adjustBackgroundOpacity ? backgroundOpacity : undefined}
-          />
+          <Widget preview={true} />
         </div>
         <div className={'flex'}>
           <button onClick={() => {

--- a/src/generator/Generator.tsx
+++ b/src/generator/Generator.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useEffect, useState} from "react";
+import {createContext, useCallback, useEffect, useState} from "react";
 import {Widget} from "../../widget/src/widget/Widget.tsx";
 import {Separator} from "../components/generator/Separator.tsx";
 import {Language, languages, tl} from "../translations/translations.ts";
@@ -11,6 +11,36 @@ import {GeneratedWidgetModal} from "../components/generator/GeneratedWidgetModal
 import {InfoBox} from "../components/generator/InfoBox.tsx";
 import packageJSON from '../../package.json'
 
+interface Settings {
+  customCSS: string,
+  autoWidth: boolean,
+  username: string,
+  onlyOfficialMatchesCount: boolean,
+  showRanking: boolean,
+  showRankingOnlyWhenChallenger: boolean,
+  showEloDiff: boolean,
+  showUsername: boolean,
+  showEloSuffix: boolean,
+  showStatistics: boolean,
+  showEloProgressBar: boolean,
+  useBannerAsBackground: boolean,
+  adjustBackgroundOpacity: boolean,
+  backgroundOpacity: number,
+  refreshInterval: number,
+  colorScheme: string,
+  theme: string,
+  customBorderColor1: string,
+  customBorderColor2: string,
+  customTextColor: string,
+  customBackgroundColor: string,
+  language: Language,
+  statSlot1: StatisticType,
+  statSlot2: StatisticType,
+  statSlot3: StatisticType,
+  statSlot4: StatisticType,
+}
+
+export const SettingsContext = createContext<Settings | null>(null)
 export const Generator = () => {
 
   const [customCSS, setCustomCSS] = useState<string>("https://example.com")
@@ -124,58 +154,51 @@ export const Generator = () => {
   const tabs = [
     {
       name: tl(language, 'generator.settings.title'),
-      component: <MainTab key={'main'} username={username} setUsername={setUsername} language={language}
-                          autoWidth={autoWidth} setAutoWidth={setAutoWidth}
-                          showUsername={showUsername} setShowUsername={setShowUsername}
+      component: <MainTab key={'main'} setUsername={setUsername}
+                          setAutoWidth={setAutoWidth}
+                          setShowUsername={setShowUsername}
                           setLanguage={setLanguage}
-                          showEloSuffix={showEloSuffix} setShowEloSuffix={setShowEloSuffix}
-                          showAverage={showStatistics}
-                          setShowAverage={setShowStatistics}
-                          showRanking={showRanking} setShowRanking={setShowRanking}
-                          showEloProgressBar={showEloProgressBar}
+                          setShowEloSuffix={setShowEloSuffix}
+                          setShowStatistics={setShowStatistics}
+                          setShowRanking={setShowRanking}
                           setShowEloProgressBar={setShowEloProgressBar}
-                          showEloDiff={showEloDiff} setShowEloDiff={setShowEloDiff}
-                          showRankingOnlyWhenChallenger={showRankingOnlyWhenChallenger}
+                          setShowEloDiff={setShowEloDiff}
                           setShowRankingOnlyWhenChallenger={setShowRankingOnlyWhenChallenger}
-                          refreshInterval={refreshInterval} setRefreshInterval={setRefreshInterval}
-                          onlyOfficialMatchesCount={onlyOfficialMatchesCount}
+                          setRefreshInterval={setRefreshInterval}
                           setOnlyOfficialMatchesCount={setOnlyOfficialMatchesCount}
       />
     },
     {
       name: tl(language, 'generator.theme.title'),
-      component: <StyleTab key={'style'} language={language} customBorderColor1={customBorderColor1}
-                           customBorderColor2={customBorderColor2}
+      component: <StyleTab key={'style'}
                            setCustomBorderColor1={setCustomBorderColor1}
                            setCustomBorderColor2={setCustomBorderColor2}
-                           customBackgroundColor={customBackgroundColor}
                            setCustomBackgroundColor={setCustomBackgroundColor}
-                           customTextColor={customTextColor} setCustomTextColor={setCustomTextColor}
-                           customCSS={customCSS} setCustomCSS={setCustomCSS}
-                           theme={theme} setTheme={setTheme} colorScheme={colorScheme}
-                           useBannerAsBackground={useBannerAsBackground}
+                           setCustomTextColor={setCustomTextColor}
+                           setCustomCSS={setCustomCSS}
+                           setTheme={setTheme}
                            setUseBannerAsBackground={setUseBannerAsBackground}
-                           adjustBackgroundOpacity={adjustBackgroundOpacity}
                            setAdjustBackgroundOpacity={setAdjustBackgroundOpacity}
-                           backgroundOpacity={backgroundOpacity}
                            setBackgroundOpacity={setBackgroundOpacity}
-
                            setColorScheme={setColorScheme}/>
     },
     {
       name: tl(language, 'generator.stats.title'),
-      component: <StatisticsTab key={'stats'} language={language} showStatistics={showStatistics}
-                                statSlot1={statSlot1} setStatSlot1={setStatSlot1}
-                                statSlot2={statSlot2} setStatSlot2={setStatSlot2}
-                                statSlot3={statSlot3} setStatSlot3={setStatSlot3}
-                                statSlot4={statSlot4} setStatSlot4={setStatSlot4}
+      component: <StatisticsTab key={'stats'} setStatSlot1={setStatSlot1} setStatSlot2={setStatSlot2}
+                                setStatSlot3={setStatSlot3} setStatSlot4={setStatSlot4}
       />
     }
   ]
 
   const [selectedTabIndex, setSelectedTabIndex] = useState(0)
 
-  return <>
+  return <SettingsContext.Provider value={{
+    customCSS, autoWidth, username, onlyOfficialMatchesCount, showRanking, showRankingOnlyWhenChallenger,
+    showEloDiff, showEloSuffix, showUsername, showStatistics, showEloProgressBar, useBannerAsBackground,
+    adjustBackgroundOpacity, backgroundOpacity, refreshInterval, colorScheme, theme, language,
+    statSlot1, statSlot2, statSlot3, statSlot4,
+    customTextColor, customBackgroundColor, customBorderColor1, customBorderColor2
+  }}>
     <GeneratedWidgetModal language={language} url={generatedURL} setURL={setGeneratedURL}/>
     <header>
       {import.meta.env.VITE_IS_TESTING &&
@@ -235,5 +258,5 @@ export const Generator = () => {
         </div>
       </section>
     </main>
-  </>
+  </SettingsContext.Provider>
 }

--- a/src/generator/Generator.tsx
+++ b/src/generator/Generator.tsx
@@ -67,7 +67,7 @@ export const Generator = () => {
       let params: { [key: string]: string | number | boolean | string[] } = {
         "player_id": id,
         "lang": language.id,
-        "eloBar": showEloProgressBar,
+        "progress": showEloProgressBar,
         "avg": showStatistics,
         "suffix": showEloSuffix,
         "diff": showEloDiff,
@@ -216,7 +216,7 @@ export const Generator = () => {
           <Widget preview={true} overrideShowEloDiff={showEloDiff} overrideShowEloSuffix={showEloSuffix}
                   overrideShowUsername={showUsername}
                   overrideRankingState={showRanking}
-                  overrideShowAverage={showStatistics}
+                  overrideShowStatistics={showStatistics}
                   overrideShowEloProgressBar={showEloProgressBar}
                   overrideUsername={username.length > 0 ? username : "Player"}
                   overrideCustomCSS={customCSS} overrideCustomScheme={colorScheme === "custom"}

--- a/src/generator/Generator.tsx
+++ b/src/generator/Generator.tsx
@@ -40,6 +40,7 @@ interface Settings {
   statSlot4: StatisticType,
 }
 
+export const LanguageContext = createContext<((text: string, args?: string[])=>string) | null>(null)
 export const SettingsContext = createContext<Settings | null>(null)
 export const Generator = () => {
 
@@ -75,6 +76,10 @@ export const Generator = () => {
 
   const [searchParams] = useSearchParams()
   const navigate = useNavigate()
+
+  const translate = useCallback((text: string, args?: string[])=>{
+    return tl(language, text, args)
+  }, [language])
 
   useEffect(() => {
     document.getElementsByTagName("html")[0].classList.add(`generator`)
@@ -192,58 +197,60 @@ export const Generator = () => {
 
   const [selectedTabIndex, setSelectedTabIndex] = useState(0)
 
-  return <SettingsContext.Provider value={{
-    customCSS, autoWidth, username, onlyOfficialMatchesCount, showRanking, showRankingOnlyWhenChallenger,
-    showEloDiff, showEloSuffix, showUsername, showStatistics, showEloProgressBar, useBannerAsBackground,
-    adjustBackgroundOpacity, backgroundOpacity, refreshInterval, colorScheme, theme, language,
-    statSlot1, statSlot2, statSlot3, statSlot4,
-    customTextColor, customBackgroundColor, customBorderColor1, customBorderColor2
-  }}>
-    <GeneratedWidgetModal language={language} url={generatedURL} setURL={setGeneratedURL}/>
-    <header>
-      {import.meta.env.VITE_IS_TESTING &&
-        <InfoBox content={<p>{tl(language, 'generator.testing')}</p>} style={'info'}/>}
-      <div className={'tabs'}>
-        {tabs.map((tab, index) => {
-          return <button key={tab.name} onClick={() => {
-            setSelectedTabIndex(index)
-          }} className={index === selectedTabIndex ? "active" : ""}>{tab.name}</button>
-        })}
-      </div>
-    </header>
-    <main>
-      <section className={'fixed-width'}>
-        {tabs[selectedTabIndex].component}
-        <br/>
-        <footer>
-          <div>
-            <small>This project is not affiliated with <a href={'https://faceit.com'}
-                                                          target={'_blank'}>FACEIT</a>.</small>
-            <small>
-              <a href={'https://github.com/mxgic1337/faceit-stats-widget/blob/master/LICENSE'} target={'_blank'}>MIT
-                License</a> &bull; <a
-              href={'https://github.com/mxgic1337/faceit-stats-widget'} target={'_blank'}>GitHub</a> &bull; <a
-              href={'https://github.com/mxgic1337/faceit-stats-widget/issues/new'} target={'_blank'}>Report an issue</a>
-            </small>
-          </div>
-          <div>
-            <small>Copyright &copy; <a href={'https://github.com/mxgic1337'}
-                                       target={'_blank'}>mxgic1337_</a> 2024</small>
-            <small>v{packageJSON.version}</small>
-          </div>
-        </footer>
-      </section>
-      <section className={'preview'}>
-        <Separator text={tl(language, 'generator.preview.title')}/>
-        <div className={`${theme}-theme ${colorScheme}-scheme preview`}>
-          <Widget preview={true} />
+  return <LanguageContext.Provider value={translate}>
+    <SettingsContext.Provider value={{
+      customCSS, autoWidth, username, onlyOfficialMatchesCount, showRanking, showRankingOnlyWhenChallenger,
+      showEloDiff, showEloSuffix, showUsername, showStatistics, showEloProgressBar, useBannerAsBackground,
+      adjustBackgroundOpacity, backgroundOpacity, refreshInterval, colorScheme, theme, language,
+      statSlot1, statSlot2, statSlot3, statSlot4,
+      customTextColor, customBackgroundColor, customBorderColor1, customBorderColor2
+    }}>
+      <GeneratedWidgetModal language={language} url={generatedURL} setURL={setGeneratedURL}/>
+      <header>
+        {import.meta.env.VITE_IS_TESTING &&
+          <InfoBox content={<p>{tl(language, 'generator.testing')}</p>} style={'info'}/>}
+        <div className={'tabs'}>
+          {tabs.map((tab, index) => {
+            return <button key={tab.name} onClick={() => {
+              setSelectedTabIndex(index)
+            }} className={index === selectedTabIndex ? "active" : ""}>{tab.name}</button>
+          })}
         </div>
-        <div className={'flex'}>
-          <button onClick={() => {
-            generateWidgetURL()
-          }}>{tl(language, 'generator.generate.button')}</button>
-        </div>
-      </section>
-    </main>
-  </SettingsContext.Provider>
+      </header>
+      <main>
+        <section className={'fixed-width'}>
+          {tabs[selectedTabIndex].component}
+          <br/>
+          <footer>
+            <div>
+              <small>This project is not affiliated with <a href={'https://faceit.com'}
+                                                            target={'_blank'}>FACEIT</a>.</small>
+              <small>
+                <a href={'https://github.com/mxgic1337/faceit-stats-widget/blob/master/LICENSE'} target={'_blank'}>MIT
+                  License</a> &bull; <a
+                href={'https://github.com/mxgic1337/faceit-stats-widget'} target={'_blank'}>GitHub</a> &bull; <a
+                href={'https://github.com/mxgic1337/faceit-stats-widget/issues/new'} target={'_blank'}>Report an issue</a>
+              </small>
+            </div>
+            <div>
+              <small>Copyright &copy; <a href={'https://github.com/mxgic1337'}
+                                         target={'_blank'}>mxgic1337_</a> 2024</small>
+              <small>v{packageJSON.version}</small>
+            </div>
+          </footer>
+        </section>
+        <section className={'preview'}>
+          <Separator text={tl(language, 'generator.preview.title')}/>
+          <div className={`${theme}-theme ${colorScheme}-scheme preview`}>
+            <Widget preview={true} />
+          </div>
+          <div className={'flex'}>
+            <button onClick={() => {
+              generateWidgetURL()
+            }}>{tl(language, 'generator.generate.button')}</button>
+          </div>
+        </section>
+      </main>
+    </SettingsContext.Provider>
+  </LanguageContext.Provider>
 }

--- a/src/generator/tabs/MainTab.tsx
+++ b/src/generator/tabs/MainTab.tsx
@@ -1,9 +1,9 @@
-import {Language, languages, tl} from "../../translations/translations.ts";
+import {Language, languages} from "../../translations/translations.ts";
 import {Checkbox} from "../../components/generator/Checkbox.tsx";
 import {Dispatch, useContext} from "react";
 import {useNavigate} from "react-router-dom";
 import {Separator} from "../../components/generator/Separator.tsx";
-import {SettingsContext} from "../Generator.tsx";
+import {LanguageContext, SettingsContext} from "../Generator.tsx";
 
 type Props = {
   setLanguage: Dispatch<Language>;
@@ -35,23 +35,24 @@ export const MainTab = ({
                           setRefreshInterval,
                         }: Props) => {
   const navigate = useNavigate();
+  const tl = useContext(LanguageContext);
   const settings = useContext(SettingsContext);
 
-  if (!settings) {
+  if (!settings || !tl) {
     return null;
   }
 
   return <>
-    <Separator text={tl(settings.language, 'generator.settings.title')}/>
+    <Separator text={tl('generator.settings.title')}/>
     <div className={'setting'}>
-      <p>{tl(settings.language, 'generator.settings.faceit_name')}</p>
+      <p>{tl('generator.settings.faceit_name')}</p>
       <input value={settings.username} max={12} onChange={(e) => {
         if (e.target.value.length > 12) return
         setUsername(e.target.value)
       }}/>
     </div>
     <div className={'setting'}>
-      <p>{tl(settings.language, 'generator.settings.language')}</p>
+      <p>{tl('generator.settings.language')}</p>
       <select value={settings.language.id} onChange={event => {
         const language = languages.find(language => language.id === event.target.value) || languages[0]
         setLanguage(language);
@@ -64,36 +65,36 @@ export const MainTab = ({
       </select>
     </div>
     <div className={'setting'}>
-      <p>{tl(settings.language, 'generator.settings.refresh_delay')}</p>
+      <p>{tl('generator.settings.refresh_delay')}</p>
       <select value={settings.refreshInterval} onChange={event => {
         setRefreshInterval(parseInt(event.currentTarget.value))
       }}>
-        <option value={10}>{tl(settings.language, 'generator.settings.refresh_delay.quick', ["10"])}</option>
-        <option value={30}>{tl(settings.language, 'generator.settings.refresh_delay.normal', ["30"])}</option>
-        <option value={60}>{tl(settings.language, 'generator.settings.refresh_delay.slow', ["60"])}</option>
+        <option value={10}>{tl('generator.settings.refresh_delay.quick', ["10"])}</option>
+        <option value={30}>{tl('generator.settings.refresh_delay.normal', ["30"])}</option>
+        <option value={60}>{tl('generator.settings.refresh_delay.slow', ["60"])}</option>
       </select>
     </div>
     <div className={'setting'}>
-      <Checkbox text={tl(settings.language, 'generator.settings.show_username')} state={settings.showUsername}
+      <Checkbox text={tl('generator.settings.show_username')} state={settings.showUsername}
                 setState={setShowUsername}/>
-      <Checkbox text={tl(settings.language, 'generator.settings.show_elo_suffix')} state={settings.showEloSuffix}
+      <Checkbox text={tl('generator.settings.show_elo_suffix')} state={settings.showEloSuffix}
                 setState={setShowEloSuffix}/>
-      <Checkbox text={tl(settings.language, 'generator.settings.show_elo_diff')} state={settings.showEloDiff}
+      <Checkbox text={tl('generator.settings.show_elo_diff')} state={settings.showEloDiff}
                 setState={setShowEloDiff}/>
-      <Checkbox text={tl(settings.language, 'generator.settings.show_elo_progress_bar')}
+      <Checkbox text={tl('generator.settings.show_elo_progress_bar')}
                 state={settings.showEloProgressBar}
                 setState={setShowEloProgressBar}/>
-      <Checkbox text={tl(settings.language, 'generator.settings.show_kd')} state={settings.showStatistics}
+      <Checkbox text={tl('generator.settings.show_kd')} state={settings.showStatistics}
                 setState={setShowStatistics}/>
-      <Checkbox text={tl(settings.language, 'generator.settings.auto_width')} state={settings.autoWidth}
+      <Checkbox text={tl('generator.settings.auto_width')} state={settings.autoWidth}
                 setState={setAutoWidth}/>
-      <Checkbox text={tl(settings.language, 'generator.settings.show_ranking')} state={settings.showRanking}
+      <Checkbox text={tl('generator.settings.show_ranking')} state={settings.showRanking}
                 setState={setShowRanking}/>
       {settings.showRanking &&
-        <Checkbox text={tl(settings.language, 'generator.settings.show_ranking_only_when_challenger')}
+        <Checkbox text={tl('generator.settings.show_ranking_only_when_challenger')}
                   state={settings.showRankingOnlyWhenChallenger}
                   setState={setShowRankingOnlyWhenChallenger}/>}
-      <Checkbox text={tl(settings.language, 'generator.settings.only_official_matches')}
+      <Checkbox text={tl('generator.settings.only_official_matches')}
                 state={settings.onlyOfficialMatchesCount}
                 setState={setOnlyOfficialMatchesCount}/>
     </div>

--- a/src/generator/tabs/MainTab.tsx
+++ b/src/generator/tabs/MainTab.tsx
@@ -91,10 +91,10 @@ export const MainTab = ({
                 setState={setShowEloProgressBar}/>
       <Checkbox text={tl(language, 'generator.settings.show_kd')} state={showAverage}
                 setState={setShowAverage}/>
-      <Checkbox text={tl(language, 'generator.settings.show_ranking')} state={showRanking}
-                setState={setShowRanking}/>
       <Checkbox text={tl(language, 'generator.settings.auto_width')} state={autoWidth}
                 setState={setAutoWidth}/>
+      <Checkbox text={tl(language, 'generator.settings.show_ranking')} state={showRanking}
+                setState={setShowRanking}/>
       {showRanking &&
         <Checkbox text={tl(language, 'generator.settings.show_ranking_only_when_challenger')}
                   state={showRankingOnlyWhenChallenger}

--- a/src/generator/tabs/MainTab.tsx
+++ b/src/generator/tabs/MainTab.tsx
@@ -1,23 +1,11 @@
 import {Language, languages, tl} from "../../translations/translations.ts";
 import {Checkbox} from "../../components/generator/Checkbox.tsx";
-import {Dispatch} from "react";
+import {Dispatch, useContext} from "react";
 import {useNavigate} from "react-router-dom";
 import {Separator} from "../../components/generator/Separator.tsx";
+import {SettingsContext} from "../Generator.tsx";
 
 type Props = {
-  language: Language;
-  username: string;
-  showUsername: boolean;
-  showEloSuffix: boolean;
-  showEloDiff: boolean;
-  showEloProgressBar: boolean;
-  showAverage: boolean;
-  showRanking: boolean;
-  autoWidth: boolean;
-  showRankingOnlyWhenChallenger: boolean;
-  onlyOfficialMatchesCount: boolean;
-  refreshInterval: number;
-
   setLanguage: Dispatch<Language>;
   setUsername: Dispatch<string>;
   setAutoWidth: Dispatch<boolean>;
@@ -25,7 +13,7 @@ type Props = {
   setShowEloSuffix: Dispatch<boolean>;
   setShowEloDiff: Dispatch<boolean>;
   setShowEloProgressBar: Dispatch<boolean>;
-  setShowAverage: Dispatch<boolean>;
+  setShowStatistics: Dispatch<boolean>;
   setShowRanking: Dispatch<boolean>;
   setShowRankingOnlyWhenChallenger: Dispatch<boolean>;
   setOnlyOfficialMatchesCount: Dispatch<boolean>;
@@ -33,33 +21,38 @@ type Props = {
 }
 
 export const MainTab = ({
-                          language, setLanguage,
-                          username, setUsername,
-                          autoWidth, setAutoWidth,
-                          showUsername, setShowUsername,
-                          showEloSuffix, setShowEloSuffix,
-                          showEloDiff, setShowEloDiff,
-                          showEloProgressBar, setShowEloProgressBar,
-                          showAverage, setShowAverage,
-                          showRanking, setShowRanking,
-                          showRankingOnlyWhenChallenger, setShowRankingOnlyWhenChallenger,
-                          onlyOfficialMatchesCount, setOnlyOfficialMatchesCount,
-                          refreshInterval, setRefreshInterval,
+                          setLanguage,
+                          setUsername,
+                          setAutoWidth,
+                          setShowUsername,
+                          setShowEloSuffix,
+                          setShowEloDiff,
+                          setShowEloProgressBar,
+                          setShowStatistics,
+                          setShowRanking,
+                          setShowRankingOnlyWhenChallenger,
+                          setOnlyOfficialMatchesCount,
+                          setRefreshInterval,
                         }: Props) => {
   const navigate = useNavigate();
+  const settings = useContext(SettingsContext);
+
+  if (!settings) {
+    return null;
+  }
 
   return <>
-    <Separator text={tl(language, 'generator.settings.title')}/>
+    <Separator text={tl(settings.language, 'generator.settings.title')}/>
     <div className={'setting'}>
-      <p>{tl(language, 'generator.settings.faceit_name')}</p>
-      <input value={username} max={12} onChange={(e) => {
+      <p>{tl(settings.language, 'generator.settings.faceit_name')}</p>
+      <input value={settings.username} max={12} onChange={(e) => {
         if (e.target.value.length > 12) return
         setUsername(e.target.value)
       }}/>
     </div>
     <div className={'setting'}>
-      <p>{tl(language, 'generator.settings.language')}</p>
-      <select value={language.id} onChange={event => {
+      <p>{tl(settings.language, 'generator.settings.language')}</p>
+      <select value={settings.language.id} onChange={event => {
         const language = languages.find(language => language.id === event.target.value) || languages[0]
         setLanguage(language);
         localStorage.setItem("fcw_lang", language.id)
@@ -71,35 +64,37 @@ export const MainTab = ({
       </select>
     </div>
     <div className={'setting'}>
-      <p>{tl(language, 'generator.settings.refresh_delay')}</p>
-      <select value={refreshInterval} onChange={event => {
+      <p>{tl(settings.language, 'generator.settings.refresh_delay')}</p>
+      <select value={settings.refreshInterval} onChange={event => {
         setRefreshInterval(parseInt(event.currentTarget.value))
       }}>
-        <option value={10}>{tl(language, 'generator.settings.refresh_delay.quick', ["10"])}</option>
-        <option value={30}>{tl(language, 'generator.settings.refresh_delay.normal', ["30"])}</option>
-        <option value={60}>{tl(language, 'generator.settings.refresh_delay.slow', ["60"])}</option>
+        <option value={10}>{tl(settings.language, 'generator.settings.refresh_delay.quick', ["10"])}</option>
+        <option value={30}>{tl(settings.language, 'generator.settings.refresh_delay.normal', ["30"])}</option>
+        <option value={60}>{tl(settings.language, 'generator.settings.refresh_delay.slow', ["60"])}</option>
       </select>
     </div>
     <div className={'setting'}>
-      <Checkbox text={tl(language, 'generator.settings.show_username')} state={showUsername}
+      <Checkbox text={tl(settings.language, 'generator.settings.show_username')} state={settings.showUsername}
                 setState={setShowUsername}/>
-      <Checkbox text={tl(language, 'generator.settings.show_elo_suffix')} state={showEloSuffix}
+      <Checkbox text={tl(settings.language, 'generator.settings.show_elo_suffix')} state={settings.showEloSuffix}
                 setState={setShowEloSuffix}/>
-      <Checkbox text={tl(language, 'generator.settings.show_elo_diff')} state={showEloDiff}
+      <Checkbox text={tl(settings.language, 'generator.settings.show_elo_diff')} state={settings.showEloDiff}
                 setState={setShowEloDiff}/>
-      <Checkbox text={tl(language, 'generator.settings.show_elo_progress_bar')} state={showEloProgressBar}
+      <Checkbox text={tl(settings.language, 'generator.settings.show_elo_progress_bar')}
+                state={settings.showEloProgressBar}
                 setState={setShowEloProgressBar}/>
-      <Checkbox text={tl(language, 'generator.settings.show_kd')} state={showAverage}
-                setState={setShowAverage}/>
-      <Checkbox text={tl(language, 'generator.settings.auto_width')} state={autoWidth}
+      <Checkbox text={tl(settings.language, 'generator.settings.show_kd')} state={settings.showStatistics}
+                setState={setShowStatistics}/>
+      <Checkbox text={tl(settings.language, 'generator.settings.auto_width')} state={settings.autoWidth}
                 setState={setAutoWidth}/>
-      <Checkbox text={tl(language, 'generator.settings.show_ranking')} state={showRanking}
+      <Checkbox text={tl(settings.language, 'generator.settings.show_ranking')} state={settings.showRanking}
                 setState={setShowRanking}/>
-      {showRanking &&
-        <Checkbox text={tl(language, 'generator.settings.show_ranking_only_when_challenger')}
-                  state={showRankingOnlyWhenChallenger}
+      {settings.showRanking &&
+        <Checkbox text={tl(settings.language, 'generator.settings.show_ranking_only_when_challenger')}
+                  state={settings.showRankingOnlyWhenChallenger}
                   setState={setShowRankingOnlyWhenChallenger}/>}
-      <Checkbox text={tl(language, 'generator.settings.only_official_matches')} state={onlyOfficialMatchesCount}
+      <Checkbox text={tl(settings.language, 'generator.settings.only_official_matches')}
+                state={settings.onlyOfficialMatchesCount}
                 setState={setOnlyOfficialMatchesCount}/>
     </div>
   </>

--- a/src/generator/tabs/StatisticsTab.tsx
+++ b/src/generator/tabs/StatisticsTab.tsx
@@ -3,7 +3,7 @@ import {InfoBox} from "../../components/generator/InfoBox.tsx";
 import {Dispatch, useContext} from "react";
 import {Statistic} from "../../components/generator/Statistic.tsx";
 import {Separator} from "../../components/generator/Separator.tsx";
-import {SettingsContext} from "../Generator.tsx";
+import {LanguageContext, SettingsContext} from "../Generator.tsx";
 
 export enum StatisticType {
   KILLS = "KILLS",
@@ -27,15 +27,16 @@ export const StatisticsTab = ({
                                 setStatSlot3,
                                 setStatSlot4
                               }: Props) => {
+  const tl = useContext(LanguageContext);
   const settings = useContext(SettingsContext);
-  if (!settings) {
+  if (!settings || !tl) {
     return null;
   }
   return <>
-    <Separator text={tl(settings.language, 'generator.stats.title')}/>
+    <Separator text={tl('generator.stats.title')}/>
     <div className={'setting stats'}>
       {!settings.showStatistics &&
-        <InfoBox content={<p>{tl(settings.language, 'generator.stats.disabled')}</p>} style={'warn'}/>}
+        <InfoBox content={<p>{tl('generator.stats.disabled')}</p>} style={'warn'}/>}
       <Statistic slot={"1"} language={settings.language} statSlot={settings.statSlot1} setStatSlot={setStatSlot1}/>
       <Statistic slot={"2"} language={settings.language} statSlot={settings.statSlot2} setStatSlot={setStatSlot2}/>
       <Statistic slot={"3"} language={settings.language} statSlot={settings.statSlot3} setStatSlot={setStatSlot3}/>

--- a/src/generator/tabs/StatisticsTab.tsx
+++ b/src/generator/tabs/StatisticsTab.tsx
@@ -1,8 +1,9 @@
-import {Language, tl} from "../../translations/translations.ts";
+import {tl} from "../../translations/translations.ts";
 import {InfoBox} from "../../components/generator/InfoBox.tsx";
-import {Dispatch} from "react";
+import {Dispatch, useContext} from "react";
 import {Statistic} from "../../components/generator/Statistic.tsx";
 import {Separator} from "../../components/generator/Separator.tsx";
+import {SettingsContext} from "../Generator.tsx";
 
 export enum StatisticType {
   KILLS = "KILLS",
@@ -14,12 +15,6 @@ export enum StatisticType {
 }
 
 interface Props {
-  language: Language;
-  showStatistics: boolean;
-  statSlot1: StatisticType;
-  statSlot2: StatisticType;
-  statSlot3: StatisticType;
-  statSlot4: StatisticType;
   setStatSlot1: Dispatch<StatisticType>;
   setStatSlot2: Dispatch<StatisticType>;
   setStatSlot3: Dispatch<StatisticType>;
@@ -27,25 +22,24 @@ interface Props {
 }
 
 export const StatisticsTab = ({
-                                language,
-                                showStatistics,
-                                statSlot1,
-                                statSlot2,
-                                statSlot3,
-                                statSlot4,
                                 setStatSlot1,
                                 setStatSlot2,
                                 setStatSlot3,
                                 setStatSlot4
                               }: Props) => {
+  const settings = useContext(SettingsContext);
+  if (!settings) {
+    return null;
+  }
   return <>
-    <Separator text={tl(language, 'generator.stats.title')}/>
+    <Separator text={tl(settings.language, 'generator.stats.title')}/>
     <div className={'setting stats'}>
-      {!showStatistics && <InfoBox content={<p>{tl(language, 'generator.stats.disabled')}</p>} style={'warn'}/>}
-      <Statistic slot={"1"} language={language} statSlot={statSlot1} setStatSlot={setStatSlot1}/>
-      <Statistic slot={"2"} language={language} statSlot={statSlot2} setStatSlot={setStatSlot2}/>
-      <Statistic slot={"3"} language={language} statSlot={statSlot3} setStatSlot={setStatSlot3}/>
-      <Statistic slot={"4"} language={language} statSlot={statSlot4} setStatSlot={setStatSlot4}/>
+      {!settings.showStatistics &&
+        <InfoBox content={<p>{tl(settings.language, 'generator.stats.disabled')}</p>} style={'warn'}/>}
+      <Statistic slot={"1"} language={settings.language} statSlot={settings.statSlot1} setStatSlot={setStatSlot1}/>
+      <Statistic slot={"2"} language={settings.language} statSlot={settings.statSlot2} setStatSlot={setStatSlot2}/>
+      <Statistic slot={"3"} language={settings.language} statSlot={settings.statSlot3} setStatSlot={setStatSlot3}/>
+      <Statistic slot={"4"} language={settings.language} statSlot={settings.statSlot4} setStatSlot={setStatSlot4}/>
     </div>
   </>
 }

--- a/src/generator/tabs/StatisticsTab.tsx
+++ b/src/generator/tabs/StatisticsTab.tsx
@@ -1,4 +1,3 @@
-import {tl} from "../../translations/translations.ts";
 import {InfoBox} from "../../components/generator/InfoBox.tsx";
 import {Dispatch, useContext} from "react";
 import {Statistic} from "../../components/generator/Statistic.tsx";

--- a/src/generator/tabs/StyleTab.tsx
+++ b/src/generator/tabs/StyleTab.tsx
@@ -1,24 +1,13 @@
 import {colorSchemes, themes} from "../../../widget/src/widget/Widget.tsx";
 import {ColorPicker} from "../../components/generator/ColorPicker.tsx";
-import {Language, tl} from "../../translations/translations.ts";
-import {Dispatch, useRef} from "react";
+import {tl} from "../../translations/translations.ts";
+import {Dispatch, useContext, useRef} from "react";
 import {Checkbox} from "../../components/generator/Checkbox.tsx";
 import {InfoBox} from "../../components/generator/InfoBox.tsx";
 import {Separator} from "../../components/generator/Separator.tsx";
+import {SettingsContext} from "../Generator.tsx";
 
 type Props = {
-  theme: string;
-  language: Language;
-  customBorderColor1: string;
-  customBorderColor2: string;
-  customTextColor: string;
-  customBackgroundColor: string;
-  customCSS: string;
-  colorScheme: string;
-  useBannerAsBackground: boolean;
-  adjustBackgroundOpacity: boolean;
-  backgroundOpacity: number;
-
   setTheme: Dispatch<string>;
   setCustomBorderColor1: Dispatch<string>;
   setCustomBorderColor2: Dispatch<string>;
@@ -32,78 +21,83 @@ type Props = {
 }
 
 export const StyleTab = ({
-                           theme, setTheme,
-                           language,
-                           colorScheme, setColorScheme,
-                           customBorderColor1, setCustomBorderColor1,
-                           customBorderColor2, setCustomBorderColor2,
-                           customTextColor, setCustomTextColor,
-                           customBackgroundColor, setCustomBackgroundColor,
-                           useBannerAsBackground, setUseBannerAsBackground,
-                           adjustBackgroundOpacity, setAdjustBackgroundOpacity,
-                           backgroundOpacity, setBackgroundOpacity,
-                           customCSS, setCustomCSS,
+                           setTheme,
+                           setColorScheme,
+                           setCustomBorderColor1,
+                           setCustomBorderColor2,
+                           setCustomTextColor,
+                           setCustomBackgroundColor,
+                           setUseBannerAsBackground,
+                           setAdjustBackgroundOpacity,
+                           setBackgroundOpacity,
+                           setCustomCSS,
                          }: Props) => {
   const customCSSInputRef = useRef<HTMLInputElement>(null);
+  const settings = useContext(SettingsContext);
+  if (!settings) {
+    return null;
+  }
 
   return <>
-    <Separator text={tl(language, 'generator.theme.title')}/>
+    <Separator text={tl(settings.language, 'generator.theme.title')}/>
     <div className={'setting'}>
       <div className={'flex'}>
         <div>
-          <p>{tl(language, 'generator.theme.color_scheme')}</p>
-          <select value={colorScheme} onChange={(e) => setColorScheme(e.target.value)}>
+          <p>{tl(settings.language, 'generator.theme.color_scheme')}</p>
+          <select value={settings.colorScheme} onChange={(e) => setColorScheme(e.target.value)}>
             {colorSchemes.map(scheme => {
-              return <option key={scheme} value={scheme}>{tl(language, `scheme.${scheme}`)}</option>
+              return <option key={scheme} value={scheme}>{tl(settings.language, `scheme.${scheme}`)}</option>
             })}
           </select>
         </div>
         <div>
-          <p>{tl(language, 'generator.theme.style')}</p>
-          <select value={theme} onChange={(e) => setTheme(e.target.value)}>
+          <p>{tl(settings.language, 'generator.theme.style')}</p>
+          <select value={settings.theme} onChange={(e) => setTheme(e.target.value)}>
             {themes.map(theme => {
               if (theme.hidden) return;
-              return <option key={theme.id} value={theme.id}>{tl(language, `theme.${theme.id}`)}</option>
+              return <option key={theme.id} value={theme.id}>{tl(settings.language, `theme.${theme.id}`)}</option>
             })}
           </select>
         </div>
       </div>
-      <Checkbox text={tl(language, 'generator.theme.banner_as_background')} state={useBannerAsBackground}
+      <Checkbox text={tl(settings.language, 'generator.theme.banner_as_background')}
+                state={settings.useBannerAsBackground}
                 setState={setUseBannerAsBackground}/>
-      {useBannerAsBackground &&
+      {settings.useBannerAsBackground &&
         <>
-          <Checkbox text={tl(language, 'generator.theme.banner_as_background.adjust_opacity')}
-                    state={adjustBackgroundOpacity}
+          <Checkbox text={tl(settings.language, 'generator.theme.banner_as_background.adjust_opacity')}
+                    state={settings.adjustBackgroundOpacity}
                     setState={setAdjustBackgroundOpacity}/>
           <div className={'flex'} style={{alignItems: 'center'}}>
-            <input type={'range'} value={backgroundOpacity} min={0.01} max={1} step={0.01}
-                   disabled={!adjustBackgroundOpacity} onChange={(event) => {
+            <input type={'range'} value={settings.backgroundOpacity} min={0.01} max={1} step={0.01}
+                   disabled={!settings.adjustBackgroundOpacity} onChange={(event) => {
               setBackgroundOpacity(parseFloat(event.currentTarget.value))
             }}/>
-            <p style={{width: '50px', textAlign: 'right'}}>{Math.round(backgroundOpacity * 100)}%</p>
+            <p style={{width: '50px', textAlign: 'right'}}>{Math.round(settings.backgroundOpacity * 100)}%</p>
           </div>
-          <InfoBox style={'info'} content={<p>{tl(language, 'generator.theme.banner_as_background.warning')}</p>}/>
+          <InfoBox style={'info'}
+                   content={<p>{tl(settings.language, 'generator.theme.banner_as_background.warning')}</p>}/>
         </>}
     </div>
 
-    {colorScheme === 'custom' && <div className={'setting'}>
-      <ColorPicker text={tl(language, 'generator.theme.border_color_1')} color={customBorderColor1}
+    {settings.colorScheme === 'custom' && <div className={'setting'}>
+      <ColorPicker text={tl(settings.language, 'generator.theme.border_color_1')} color={settings.customBorderColor1}
                    setColor={setCustomBorderColor1}/>
-      <ColorPicker text={tl(language, 'generator.theme.border_color_2')} color={customBorderColor2}
+      <ColorPicker text={tl(settings.language, 'generator.theme.border_color_2')} color={settings.customBorderColor2}
                    setColor={setCustomBorderColor2}/>
-      <ColorPicker text={tl(language, 'generator.theme.text_color')}
-                   color={customTextColor} setColor={setCustomTextColor}/>
-      <ColorPicker text={tl(language, 'generator.theme.background_color')}
-                   color={customBackgroundColor} setColor={setCustomBackgroundColor}/>
+      <ColorPicker text={tl(settings.language, 'generator.theme.text_color')}
+                   color={settings.customTextColor} setColor={setCustomTextColor}/>
+      <ColorPicker text={tl(settings.language, 'generator.theme.background_color')}
+                   color={settings.customBackgroundColor} setColor={setCustomBackgroundColor}/>
     </div>}
 
-    {theme === 'custom' && <div className={'setting'}>
-      <p>{tl(language, 'generator.theme.custom_css.title')}</p>
-      <input defaultValue={customCSS} ref={customCSSInputRef} onKeyDown={(e) => {
+    {settings.theme === 'custom' && <div className={'setting'}>
+      <p>{tl(settings.language, 'generator.theme.custom_css.title')}</p>
+      <input defaultValue={settings.customCSS} ref={customCSSInputRef} onKeyDown={(e) => {
         if (e.code !== "Enter") return
         setCustomCSS(customCSSInputRef.current?.value as string)
       }}/>
-      <small>{tl(language, 'generator.theme.custom_css.apply')}</small>
+      <small>{tl(settings.language, 'generator.theme.custom_css.apply')}</small>
     </div>}
   </>
 }

--- a/src/generator/tabs/StyleTab.tsx
+++ b/src/generator/tabs/StyleTab.tsx
@@ -1,11 +1,10 @@
 import {colorSchemes, themes} from "../../../widget/src/widget/Widget.tsx";
 import {ColorPicker} from "../../components/generator/ColorPicker.tsx";
-import {tl} from "../../translations/translations.ts";
 import {Dispatch, useContext, useRef} from "react";
 import {Checkbox} from "../../components/generator/Checkbox.tsx";
 import {InfoBox} from "../../components/generator/InfoBox.tsx";
 import {Separator} from "../../components/generator/Separator.tsx";
-import {SettingsContext} from "../Generator.tsx";
+import {LanguageContext, SettingsContext} from "../Generator.tsx";
 
 type Props = {
   setTheme: Dispatch<string>;
@@ -33,39 +32,40 @@ export const StyleTab = ({
                            setCustomCSS,
                          }: Props) => {
   const customCSSInputRef = useRef<HTMLInputElement>(null);
+  const tl = useContext(LanguageContext);
   const settings = useContext(SettingsContext);
-  if (!settings) {
+  if (!settings || !tl) {
     return null;
   }
 
   return <>
-    <Separator text={tl(settings.language, 'generator.theme.title')}/>
+    <Separator text={tl('generator.theme.title')}/>
     <div className={'setting'}>
       <div className={'flex'}>
         <div>
-          <p>{tl(settings.language, 'generator.theme.color_scheme')}</p>
+          <p>{tl('generator.theme.color_scheme')}</p>
           <select value={settings.colorScheme} onChange={(e) => setColorScheme(e.target.value)}>
             {colorSchemes.map(scheme => {
-              return <option key={scheme} value={scheme}>{tl(settings.language, `scheme.${scheme}`)}</option>
+              return <option key={scheme} value={scheme}>{tl(`scheme.${scheme}`)}</option>
             })}
           </select>
         </div>
         <div>
-          <p>{tl(settings.language, 'generator.theme.style')}</p>
+          <p>{tl('generator.theme.style')}</p>
           <select value={settings.theme} onChange={(e) => setTheme(e.target.value)}>
             {themes.map(theme => {
               if (theme.hidden) return;
-              return <option key={theme.id} value={theme.id}>{tl(settings.language, `theme.${theme.id}`)}</option>
+              return <option key={theme.id} value={theme.id}>{tl(`theme.${theme.id}`)}</option>
             })}
           </select>
         </div>
       </div>
-      <Checkbox text={tl(settings.language, 'generator.theme.banner_as_background')}
+      <Checkbox text={tl('generator.theme.banner_as_background')}
                 state={settings.useBannerAsBackground}
                 setState={setUseBannerAsBackground}/>
       {settings.useBannerAsBackground &&
         <>
-          <Checkbox text={tl(settings.language, 'generator.theme.banner_as_background.adjust_opacity')}
+          <Checkbox text={tl('generator.theme.banner_as_background.adjust_opacity')}
                     state={settings.adjustBackgroundOpacity}
                     setState={setAdjustBackgroundOpacity}/>
           <div className={'flex'} style={{alignItems: 'center'}}>
@@ -76,28 +76,28 @@ export const StyleTab = ({
             <p style={{width: '50px', textAlign: 'right'}}>{Math.round(settings.backgroundOpacity * 100)}%</p>
           </div>
           <InfoBox style={'info'}
-                   content={<p>{tl(settings.language, 'generator.theme.banner_as_background.warning')}</p>}/>
+                   content={<p>{tl('generator.theme.banner_as_background.warning')}</p>}/>
         </>}
     </div>
 
     {settings.colorScheme === 'custom' && <div className={'setting'}>
-      <ColorPicker text={tl(settings.language, 'generator.theme.border_color_1')} color={settings.customBorderColor1}
+      <ColorPicker text={tl('generator.theme.border_color_1')} color={settings.customBorderColor1}
                    setColor={setCustomBorderColor1}/>
-      <ColorPicker text={tl(settings.language, 'generator.theme.border_color_2')} color={settings.customBorderColor2}
+      <ColorPicker text={tl('generator.theme.border_color_2')} color={settings.customBorderColor2}
                    setColor={setCustomBorderColor2}/>
-      <ColorPicker text={tl(settings.language, 'generator.theme.text_color')}
+      <ColorPicker text={tl('generator.theme.text_color')}
                    color={settings.customTextColor} setColor={setCustomTextColor}/>
-      <ColorPicker text={tl(settings.language, 'generator.theme.background_color')}
+      <ColorPicker text={tl('generator.theme.background_color')}
                    color={settings.customBackgroundColor} setColor={setCustomBackgroundColor}/>
     </div>}
 
     {settings.theme === 'custom' && <div className={'setting'}>
-      <p>{tl(settings.language, 'generator.theme.custom_css.title')}</p>
+      <p>{tl('generator.theme.custom_css.title')}</p>
       <input defaultValue={settings.customCSS} ref={customCSSInputRef} onKeyDown={(e) => {
         if (e.code !== "Enter") return
         setCustomCSS(customCSSInputRef.current?.value as string)
       }}/>
-      <small>{tl(settings.language, 'generator.theme.custom_css.apply')}</small>
+      <small>{tl('generator.theme.custom_css.apply')}</small>
     </div>}
   </>
 }

--- a/src/styles/app.less
+++ b/src/styles/app.less
@@ -194,8 +194,10 @@ section.preview {
 
   .check {
     @size: 16px;
-    width: @size;
-    height: @size;
+    min-width: @size;
+    min-height: @size;
+    max-width: @size;
+    max-height: @size;
     border: 1px solid @border;
     border-radius: 6px;
     margin-right: 4px;

--- a/src/styles/app.less
+++ b/src/styles/app.less
@@ -5,13 +5,15 @@
 
 @import '../../widget/src/styles/color_schemes';
 
+@background: #111;
+@background-input: #1c1c1c;
 @border: #2c2c2c;
-@hover: #b3b3b3;
+@border-focus: #5d5d5d;
 @active: #fafafa;
 
 @text: #fafafa;
+@disabled: #575757;
 @subtext: #bebebe;
-@accent: #cba6f7;
 
 @info: #5ba6e5;
 @warn: #d7a141;
@@ -24,23 +26,20 @@
 }
 
 #root {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
   width: 100vw;
   height: 100vh;
-
+  overflow-y: auto;
   padding: 6px;
   box-sizing: border-box;
 }
 
 body {
-  background: #111;
+  background: @background;
 }
 
 input, select, button {
   border: 1px solid @border;
-  background: #1c1c1c;
+  background: @background-input;
   padding: 6px;
   border-radius: 6px;
   outline: none;
@@ -50,7 +49,7 @@ input, select, button {
   margin: 6px 0;
 
   &:focus {
-    border: 1px solid #5d5d5d;
+    border: 1px solid @border-focus;
   }
 }
 
@@ -58,7 +57,7 @@ button {
   cursor: pointer;
 
   &:hover {
-    border: 1px solid #5d5d5d;
+    border: 1px solid @border-focus;
   }
 }
 
@@ -76,7 +75,9 @@ button {
 }
 
 main {
+  margin: auto;
   display: flex;
+
   padding: 12px;
   border-radius: 6px;
   width: 70%;
@@ -104,9 +105,15 @@ main {
   }
 
   button:disabled {
-    color: #575757;
+    color: @disabled;
     border: 1px solid @border;
     cursor: not-allowed;
+  }
+}
+
+@media only screen and (max-width: 1240px) {
+  main {
+    width: 95%;
   }
 }
 
@@ -130,6 +137,7 @@ main {
 }
 
 header {
+  margin: auto;
   padding: 6px;
   width: 70%;
   box-sizing: border-box;
@@ -184,6 +192,29 @@ section.preview {
   max-width: 450px;
   flex-direction: column;
   justify-content: flex-start;
+}
+
+@media only screen and (max-width: 820px) {
+  main {
+    box-sizing: border-box;
+    width: 100%;
+    height: auto;
+    max-height: initial;
+    flex-direction: column-reverse;
+
+    section.preview {
+      min-width: 0;
+      max-width: 100%;
+      width: 100%;
+      margin-left: 0;
+      box-sizing: border-box;
+      max-height: 231px;
+    }
+
+    div.preview {
+      width: 100%;
+    }
+  }
 }
 
 .checkbox {
@@ -253,7 +284,7 @@ section.preview {
     &:hover {
       border: none;
       border-radius: 0;
-      border-bottom: 1px solid @hover;
+      border-bottom: 1px solid @border-focus;
     }
 
     &.active {

--- a/src/translations/english.json
+++ b/src/translations/english.json
@@ -40,7 +40,7 @@
   "generator.theme.style": "Widget style",
   "generator.theme.banner_as_background": "Use profile banner as background",
   "generator.theme.banner_as_background.warning": "The preview shows an example banner. Correct banner will show after generating the widget.",
-  "generator.theme.banner_as_background.adjust_opacity": "Adjust background opacity",
+  "generator.theme.banner_as_background.adjust_opacity": "Adjust banner opacity",
   "generator.generate.title": "Generate",
   "generator.generate.button": "Generate",
   "generator.generate.open_in_browser.button": "Open in Browser",

--- a/src/translations/polish.json
+++ b/src/translations/polish.json
@@ -39,7 +39,7 @@
   "generator.theme.style": "Styl widżetu",
   "generator.theme.banner_as_background": "Użyj baneru profilu jako tła",
   "generator.theme.banner_as_background.warning": "Podgląd pokazuje przykładowy baner. Poprawny baner wyświetli się dopiero po wygenerowaniu widżetu.",
-  "generator.theme.banner_as_background.adjust_opacity": "Dostosuj przezroczystość tła",
+  "generator.theme.banner_as_background.adjust_opacity": "Dostosuj przezroczystość baneru",
   "generator.generate.title": "Wygeneruj widżet",
   "generator.generate.button": "Wygeneruj",
   "generator.generate.open_in_browser.button": "Otwórz w przeglądarce",

--- a/widget/src/widget/Widget.tsx
+++ b/widget/src/widget/Widget.tsx
@@ -54,7 +54,7 @@ interface Props {
   overrideCustomScheme?: boolean,
   overrideLanguage?: string,
   overrideRankingState?: boolean,
-  overrideShowAverage?: boolean,
+  overrideShowStatistics?: boolean,
   overrideShowEloDiff?: boolean,
   overrideShowEloProgressBar?: boolean,
   overrideShowEloSuffix?: boolean,
@@ -109,7 +109,7 @@ export const Widget = ({
                          overrideCustomCSS,
                          overrideLanguage,
                          overrideUseBannerAsBackground,
-                         overrideShowAverage,
+                         overrideShowStatistics,
                          overrideShowEloDiff,
                          overrideShowEloSuffix,
                          overrideShowEloProgressBar
@@ -131,9 +131,14 @@ export const Widget = ({
   const [banner, setBanner] = useState<string>()
   const [showUsername, setShowUsername] = useState<boolean>(false)
   const [useBannerAsBackground, setUseBannerAsBackground] = useState<boolean>(false)
-  const [backgroundOpacity, setBackgroundOpacity] = useState<number>()
+  const [backgroundOpacity, setBackgroundOpacity] = useState<number | undefined>()
   const [currentEloDistribution, setCurrentEloDistribution] = useState<(string | number)[]>(eloDistribution[0])
   const [rankingState, setRankingState] = useState<RankingState>(0)
+
+  const [showEloDiff, setShowEloDiff] = useState<boolean>()
+  const [showEloSuffix, setShowEloSuffix] = useState<boolean>()
+  const [showStatistics, setShowStatistics] = useState<boolean>()
+  const [showEloProgressBar, setShowEloProgressBar] = useState<boolean>()
 
   const [customColorScheme, setCustomColorScheme] = useState<boolean>()
   const [customColor, setCustomColor] = useState<string>()
@@ -141,70 +146,125 @@ export const Widget = ({
   const [customBorderColor, setCustomBorderColor] = useState<string>()
   const [customBorderColor2, setCustomBorderColor2] = useState<string>()
 
+  /* Apply settings from query params */
   useLayoutEffect(() => {
     if (preview) return;
-    const theme = searchParams.get('theme');
-    const scheme = searchParams.get('scheme');
-    const name = searchParams.get('name');
-    const official = searchParams.get('only_official');
-    const stats = searchParams.get('stats');
+    const languageParam = searchParams.get('lang');
+    let themeParam = searchParams.get('theme');
+    let colorSchemeParam = searchParams.get('scheme');
+    const showUsernameParam = searchParams.get('name');
+    const onlyOfficialParam = searchParams.get('only_official');
+    const statsParam = searchParams.get('stats');
+    const showEloDiffParam = searchParams.get('diff');
+    const showEloSuffixParam = searchParams.get('suffix');
+    const showStatisticsParam = searchParams.get('avg');
+    const rankingParam = searchParams.get('ranking');
+    const useBannerAsBackgroundParam = searchParams.get('banner');
+    const backgroundOpacityParam = searchParams.get("banner_opacity");
+    const autoWidthParam = searchParams.get('auto_width');
+    const showEloProgressBarParam = searchParams.get('progress');
+    const showEloProgressBarOldParam = searchParams.get('eloBar');
 
-    if (stats) {
-      setStats(stats.split(',') as StatisticType[])
+    /* Redirect old theme format to new theme & style format */
+    if (themeParam === 'dark' || themeParam === 'normal-custom') {
+      themeParam = 'normal'
+      colorSchemeParam = 'dark'
+    } else if ((themeParam === 'compact' && !colorSchemeParam) || themeParam === 'compact-custom') {
+      themeParam = 'compact'
+      if (themeParam === 'compact-custom') {
+        colorSchemeParam = 'custom'
+      } else {
+        colorSchemeParam = 'dark'
+      }
+    } else if (themeParam === 'classic' && !colorSchemeParam) {
+      colorSchemeParam = 'faceit'
     }
 
-    if (!name || name === 'true') {
-      setShowUsername(true)
+    if (statsParam) {
+      setStats(statsParam.split(',') as StatisticType[])
     }
 
-    if (!official) {
+    if (!onlyOfficialParam) {
       searchParams.set('only_official', 'true')
     }
 
-    setUseBannerAsBackground(searchParams.get('banner') === 'true')
-    if (theme === 'dark' || theme === 'normal-custom') {
-      searchParams.set('theme', 'normal');
-      searchParams.set('scheme', 'dark');
-    } else if ((theme === 'compact' && !scheme) || theme === 'compact-custom') {
-      searchParams.set('theme', 'compact');
-      if (theme === 'compact-custom') {
-        searchParams.set('scheme', 'custom');
-      } else {
-        searchParams.set('scheme', 'dark');
-      }
-    } else if (theme === 'classic' && !scheme) {
-      searchParams.set('scheme', 'faceit');
+    setShowUsername(!showUsernameParam || showUsernameParam === 'true')
+    setShowEloDiff(!showEloDiffParam || showEloDiffParam === 'true')
+    setShowEloSuffix(!showEloSuffixParam || showEloSuffixParam === 'true')
+    setShowStatistics(showStatisticsParam === 'true')
+    setUseBannerAsBackground(useBannerAsBackgroundParam === 'true')
+    setShowEloProgressBar((showEloProgressBarParam || showEloProgressBarOldParam) === 'true')
+
+    if (rankingParam) {
+      setRankingState(rankingParam === '2' ? RankingState.ONLY_WHEN_CHALLENGER : RankingState.SHOW)
+    } else {
+      setRankingState(RankingState.DISABLED)
     }
-  }, []);
 
-  useEffect(() => {
-    if (!preview) return;
-    setStats(overrideStatistics as StatisticType[])
-    setShowUsername(overrideShowUsername as boolean)
-  }, [overrideStatistics, overrideShowUsername,]);
+    if (backgroundOpacityParam) {
+      setBackgroundOpacity(parseFloat(backgroundOpacityParam));
+    }
 
-  useEffect(() => {
-    if (searchParams.get('scheme') === 'custom') {
+    if (colorSchemeParam === 'custom') {
       setCustomColorScheme(true)
       setCustomColor(`#${searchParams.get('color')}`)
       setCustomBackgroundColor(`#${searchParams.get('bg-color')}`)
       setCustomBorderColor(`#${searchParams.get('border1')}`)
       setCustomBorderColor2(`#${searchParams.get('border2')}`)
-    } else if (preview && overrideCustomScheme) {
-      setCustomColorScheme(true)
-      setCustomColor(overrideTextColor)
-      setCustomBackgroundColor(overrideBackground)
-      setCustomBorderColor(overrideBorder1)
-      setCustomBorderColor2(overrideBorder2)
-
-    } else {
-      setCustomColorScheme(false)
     }
-  }, [overrideTextColor, overrideBackground, overrideBorder1, overrideBorder2, overrideCustomScheme]);
+
+    let theme = themeParam;
+    let scheme = colorSchemeParam;
+
+    if (!themes.find(theme1 => theme1.id === theme)) {
+      theme = 'normal'
+    }
+    if (!colorSchemes.find(scheme1 => scheme1 === scheme)) {
+      scheme = 'dark'
+    }
+
+    document.getElementsByTagName("html")[0].classList.add(`${theme}-theme`)
+    document.getElementsByTagName("html")[0].classList.add(`${scheme}-scheme`)
+    if (autoWidthParam === 'true') {
+      document.getElementsByTagName("html")[0].classList.add(`auto-width`)
+    }
+
+    const language = languages.find(language => language.id === languageParam);
+    if (language) setLanguage(language);
+
+    return () => {
+      document.getElementsByTagName("html")[0].classList.remove(`${theme}-theme`)
+      document.getElementsByTagName("html")[0].classList.remove(`${scheme}-scheme`)
+      if (autoWidthParam === 'true') {
+        document.getElementsByTagName("html")[0].classList.remove(`auto-width`)
+      }
+    }
+  }, []);
+
+  /* Apply settings from preview */
+  useLayoutEffect(() => {
+    if (!preview) return;
+    setStats(overrideStatistics as StatisticType[])
+    setShowUsername(overrideShowUsername as boolean)
+    setShowEloDiff(overrideShowEloDiff as boolean)
+    setShowEloSuffix(overrideShowEloSuffix as boolean)
+    setBackgroundOpacity(overrideBackgroundOpacity as number)
+    setShowStatistics(overrideShowStatistics as boolean)
+    setRankingState(overrideRankingState ? RankingState.SHOW : RankingState.DISABLED)
+    setUseBannerAsBackground(overrideUseBannerAsBackground as boolean)
+    setLanguage(languages.find(language => language.id === overrideLanguage) || languages[0])
+    setCustomColorScheme(overrideCustomScheme)
+    setCustomColor(overrideTextColor)
+    setCustomBackgroundColor(overrideBackground)
+    setCustomBorderColor(overrideBorder1)
+    setCustomBorderColor2(overrideBorder2)
+    setShowEloProgressBar(overrideShowEloProgressBar)
+  }, [overrideBackgroundOpacity, overrideCustomScheme, overrideTextColor, overrideBackground, overrideBorder1, overrideBorder2, overrideRankingState, overrideShowStatistics, overrideStatistics, overrideShowUsername, overrideShowEloDiff, overrideShowEloSuffix, overrideUseBannerAsBackground]);
 
   const [searchParams] = useSearchParams()
   const navigate = useNavigate()
 
+  /** Returns a path to a level icon */
   const getIcon = useCallback(() => {
     if (preview) return levelIcons[10]
     if (level === 10 && ranking <= 1000) {
@@ -216,6 +276,7 @@ export const Widget = ({
     return levelIcons[level - 1]
   }, [level, ranking, preview])
 
+  /** Returns a color, min ELO and max ELO of a level */
   const getEloDistribution = useCallback((level: number, ranking: number) => {
     if (preview) return eloDistribution[10]
     if (level === 10 && ranking <= 1000) {
@@ -227,36 +288,14 @@ export const Widget = ({
     return eloDistribution[level - 1]
   }, [preview])
 
-  useEffect(() => {
-    const language = languages.find(language => language.id === searchParams.get('lang'));
-    if (language) setLanguage(language);
-  }, [overrideLanguage, searchParams]);
-
+  /* Update player stats */
   useEffect(() => {
     if (preview) {
       setCurrentEloDistribution(eloDistribution[10]);
       return;
     }
-    let rankingParam = parseInt(searchParams.get('ranking') || "2");
-    console.log(searchParams.get('ranking'), rankingParam)
-    if (isNaN(rankingParam)) rankingParam = RankingState.ONLY_WHEN_CHALLENGER
-    setRankingState(rankingParam)
 
     const startDate = new Date();
-
-    let theme = searchParams.get("theme") || "normal";
-    let scheme = searchParams.get("scheme") || "dark";
-    const backgroundOpacity = searchParams.get("banner_opacity");
-    if (!themes.find(theme1 => theme1.id === theme)) {
-      theme = "normal"
-    }
-    if (!colorSchemes.find(scheme1 => scheme1 === scheme)) {
-      scheme = "dark"
-    }
-
-    if (backgroundOpacity) {
-      setBackgroundOpacity(parseFloat(backgroundOpacity));
-    }
 
     const playerId = searchParams.get("player_id")
     const samplePlayerId = '24180323-d946-4bb7-a334-be3e96fcac05'
@@ -311,38 +350,31 @@ export const Widget = ({
 
     const interval =
       setInterval(getStats, 1000 * refreshDelay)
-    document.getElementsByTagName("html")[0].classList.add(`${theme}-theme`)
-    document.getElementsByTagName("html")[0].classList.add(`${scheme}-scheme`)
-    if (searchParams.get('auto_width') === 'true') {
-      document.getElementsByTagName("html")[0].classList.add(`auto-width`)
-    }
-
     return () => {
       clearInterval(interval)
-      document.getElementsByTagName("html")[0].classList.remove(`${theme}-theme`)
-      document.getElementsByTagName("html")[0].classList.remove(`${scheme}-scheme`)
     }
   }, [])
 
+  /* Custom CSS */
   useEffect(() => {
-    if (!searchParams.get("theme") || searchParams.get("theme") !== "custom") return
+    if (searchParams.get('theme') !== 'custom') return
 
-    const cssPath = overrideCustomCSS || searchParams.get("css") || undefined
+    const cssPath = overrideCustomCSS || searchParams.get('css') || undefined
     if (!cssPath) return;
 
     const head = document.head;
-    const link = document.createElement("link");
-    link.type = "text/css";
-    link.rel = "stylesheet";
+    const link = document.createElement('link');
+    link.type = 'text/css';
+    link.rel = 'stylesheet';
     link.href = cssPath;
 
     head.appendChild(link);
     return () => {
       head.removeChild(link);
     }
-
   }, [overrideCustomCSS, overrideCustomScheme])
 
+  /** Returns player statistic */
   const getStat = useCallback((stat: StatisticType) => {
     switch (stat) {
       case StatisticType.KILLS:
@@ -362,6 +394,22 @@ export const Widget = ({
     }
   }, [kills, deaths, winsPercent, hsPercent, ranking, avgMatches])
 
+  /** Returns player ELO text */
+  const getElo = useCallback(() => {
+    const currentElo = preview ? 2001 : elo
+    let diff = 0
+
+    if (!preview) {
+      diff = elo - startingElo
+    }
+
+    let text = tl(language, `widget.elo${!showEloSuffix ? "_no_suffix" : ""}`, [String(currentElo)])
+    if (showEloDiff) {
+      text += tl(language, `widget.elo_diff`, [`${diff >= 0 ? `+${diff}` : String(diff)}`])
+    }
+    return text;
+  }, [language, elo, startingElo, showEloDiff, showEloSuffix]);
+
   return (
     <>
       {customColorScheme && <style>{`
@@ -374,10 +422,10 @@ export const Widget = ({
                     --background: ${customBackgroundColor} !important;
                 }
             `}</style>}
-      {(overrideUseBannerAsBackground || useBannerAsBackground) && <style>{`
+      {useBannerAsBackground && <style>{`
                 .wrapper {
-                    --background-url: url("${overrideUseBannerAsBackground ? sampleBanner : banner}") !important;
-                    ${overrideBackgroundOpacity || backgroundOpacity ? `--background-opacity: ${overrideBackgroundOpacity || backgroundOpacity} !important;` : ""}
+                    --background-url: url("${preview ? sampleBanner : banner}") !important;
+                    ${backgroundOpacity ? `--background-opacity: ${backgroundOpacity} !important;` : ""}
                 }
             `}</style>}
       <div className={'wrapper'}>
@@ -387,12 +435,12 @@ export const Widget = ({
               <img src={getIcon()}
                    alt={`Level ${preview ? 10 : level}`}/>
               <div className={'elo'}>
-                {showUsername && <h2>{username || searchParams.get("player") || overrideUsername || "?"}</h2>}
+                {showUsername && <h2>{username || overrideUsername || "?"}</h2>}
                 <p
-                  className={showUsername ? "" : "username-hidden"}>{(overrideRankingState || (rankingState === RankingState.ONLY_WHEN_CHALLENGER && ranking <= 1000) || rankingState === RankingState.SHOW) &&
-                  <span
-                    className={'ranking'}>#{ranking} </span>}{tl(language, `widget.elo${(preview && overrideShowEloSuffix) || (!preview && (searchParams.get('suffix') === null || searchParams.get('suffix') === 'true')) ? '' : '_no_suffix'}`, [preview ? `2001` : `${elo}`])
-                  + ((preview && overrideShowEloDiff) || (!preview && (searchParams.get('diff') === 'true' || searchParams.get('diff') === null)) ? tl(language, 'widget.elo_diff', [0 > elo - startingElo ? `${elo - startingElo}` : `+${elo - startingElo}`]) : "")}</p>
+                  className={showUsername ? "" : "username-hidden"}>
+                  {((rankingState === RankingState.ONLY_WHEN_CHALLENGER && ranking <= 1000) || rankingState === RankingState.SHOW) &&
+                    <span
+                      className={'ranking'}>#{ranking} </span>}{getElo()}</p>
               </div>
             </div>
             <div className={'matches'}>
@@ -402,7 +450,7 @@ export const Widget = ({
               </div>
             </div>
           </div>
-          {((preview && overrideShowAverage) || (!preview && searchParams.get('avg') === 'true')) &&
+          {showStatistics &&
             <div className={'average'}>
               {stats.map(stat => {
                 return <div className={'stat'}>
@@ -411,7 +459,7 @@ export const Widget = ({
                 </div>
               })}
             </div>}
-          {((preview && overrideShowEloProgressBar) || (!preview && searchParams.get('eloBar') === 'true')) &&
+          {showEloProgressBar &&
             <div className={'progress-bar'}>
               <div className={'progress'} style={{
                 width: preview || level === 10 ? '100%' : `${((elo - (currentEloDistribution[1] as number)) / ((currentEloDistribution[2] as number) - (currentEloDistribution[1] as number))) * 100}%`,

--- a/widget/src/widget/Widget.tsx
+++ b/widget/src/widget/Widget.tsx
@@ -107,6 +107,10 @@ export const Widget = ({preview}: { preview: boolean }) => {
   const [customBorderColor, setCustomBorderColor] = useState<string>()
   const [customBorderColor2, setCustomBorderColor2] = useState<string>()
   const overrides = useContext(SettingsContext);
+  
+  const translate = useCallback((text: string, args?: string[])=>{
+    return tl(language, text, args)
+  }, [language])
 
   /* Apply settings from query params */
   useLayoutEffect(() => {
@@ -365,9 +369,9 @@ export const Widget = ({preview}: { preview: boolean }) => {
       diff = elo - startingElo
     }
 
-    let text = tl(language, `widget.elo${!showEloSuffix ? "_no_suffix" : ""}`, [String(currentElo)])
+    let text = translate(`widget.elo${!showEloSuffix ? "_no_suffix" : ""}`, [String(currentElo)])
     if (showEloDiff) {
-      text += tl(language, `widget.elo_diff`, [`${diff >= 0 ? `+${diff}` : String(diff)}`])
+      text += translate(`widget.elo_diff`, [`${diff >= 0 ? `+${diff}` : String(diff)}`])
     }
     return text;
   }, [language, elo, startingElo, showEloDiff, showEloSuffix]);
@@ -407,8 +411,8 @@ export const Widget = ({preview}: { preview: boolean }) => {
             </div>
             <div className={'matches'}>
               <div className={'stats'}>
-                <Statistic color={'green'} value={String(wins)} text={tl(language, 'widget.wins')}/>
-                <Statistic color={'red'} value={String(losses)} text={tl(language, 'widget.losses')}/>
+                <Statistic color={'green'} value={String(wins)} text={translate('widget.wins')}/>
+                <Statistic color={'red'} value={String(losses)} text={translate('widget.losses')}/>
               </div>
             </div>
           </div>
@@ -416,7 +420,7 @@ export const Widget = ({preview}: { preview: boolean }) => {
             <div className={'average'}>
               {stats.map(stat => {
                 return <div className={'stat'}>
-                  <p>{tl(language, `widget.${stat.toLowerCase()}`)}</p>
+                  <p>{translate(`widget.${stat.toLowerCase()}`)}</p>
                   <p>{getStat(stat)}</p>
                 </div>
               })}


### PR DESCRIPTION
- [x] (Widget) Move loading settings from query parameters to one place
- [x] (Widget) Use settings from context instead of overrides
- [x] (Generator) Use `useContext` for generator settings
- [x] (Generator) Fix mobile view