### PR TITLE
fix(widget): count NA queue as official

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "faceit-stats-widget",
   "private": true,
-  "version": "3.5.1",
+  "version": "3.5.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/widget/src/styles/color_schemes.less
+++ b/widget/src/styles/color_schemes.less
@@ -56,20 +56,24 @@
 
 .ctp-latte-scheme {
   #scheme(#4c4f69, #6c6f85, #eff1f5, #acb0be, #acb0be, 0deg, #40a02b, #d20f39, 0.25);
-  #scheme-levels(#eff1f5, #40a02b, #df8e1d, #fe640b, #d20f39, #d20f39, #df8e1d, #bcc0cc, #fe640b);
+  //#scheme-levels(#eff1f5, #40a02b, #df8e1d, #fe640b, #d20f39, #d20f39, #df8e1d, #bcc0cc, #fe640b);
+  #scheme-levels();
 }
 
 .ctp-frappe-scheme {
   #scheme(#c6d0f5, #a5adce, #303446, #8caaee, #8caaee, 0deg, #a6d189, #e78284, 0.15);
-  #scheme-levels(#c6d0f5, #a6d189, #e5c890, #ef9f76, #e78284, #e78284, #e5c890, #a5adce, #ef9f76);
+  //#scheme-levels(#c6d0f5, #a6d189, #e5c890, #ef9f76, #e78284, #e78284, #e5c890, #a5adce, #ef9f76);
+  #scheme-levels();
 }
 
 .ctp-macchiato-scheme {
   #scheme(#cad3f5, #a5adcb, #24273a, #c6a0f6, #c6a0f6, 0deg, #a6e3a1, #f38ba8, 0.15);
-  #scheme-levels(#cad3f5, #a6da95, #eed49f, #f5a97f, #ed8796, #ed8796, #eed49f, #a5adcb, #f5a97f);
+  //#scheme-levels(#cad3f5, #a6da95, #eed49f, #f5a97f, #ed8796, #ed8796, #eed49f, #a5adcb, #f5a97f);
+  #scheme-levels();
 }
 
 .ctp-mocha-scheme {
   #scheme(#cdd6f4, #a6adc8, #1e1e2e, #cba6f7, #cba6f7, 0deg, #a6e3a1, #f38ba8);
-  #scheme-levels(#cdd6f4, #a6e3a1, #f9e2af, #fab387, #f38ba8, #f38ba8, #f9e2af, #a6adc8, #fab387);
+  //#scheme-levels(#cdd6f4, #a6e3a1, #f9e2af, #fab387, #f38ba8, #f38ba8, #f9e2af, #a6adc8, #fab387);
+  #scheme-levels();
 }

--- a/widget/src/utils/faceit_util.ts
+++ b/widget/src/utils/faceit_util.ts
@@ -3,7 +3,10 @@ export const API_KEY = import.meta.env.VITE_FACEIT_API_KEY;
 export const SAMPLE_PLAYER_ID = '24180323-d946-4bb7-a334-be3e96fcac05';
 
 /** Competition ID of official matches */
-export const OFFICIAL_COMPETITION_ID = 'f4148ddd-bce8-41b8-9131-ee83afcdd6dd';
+export const OFFICIAL_COMPETITION_IDS = [
+  'f4148ddd-bce8-41b8-9131-ee83afcdd6dd' /* EU Queue */,
+  '3aced33b-f21c-450c-91d5-10535164e0ab' /* NA Queue*/,
+];
 
 /** Info about player returned by API v4 */
 interface V4PlayersResponse {
@@ -122,7 +125,10 @@ export function getPlayerStats(
 
         for (const match of v4HistoryResponse.items) {
           /* Count only official matches */
-          if (onlyOfficial && match.competition_id !== OFFICIAL_COMPETITION_ID)
+          if (
+            onlyOfficial &&
+            !OFFICIAL_COMPETITION_IDS.includes(match.competition_id)
+          )
             continue;
           if (match.finished_at < startDate.getTime() / 1000) continue;
           /* Player's team name */


### PR DESCRIPTION
Closes #59

Fixes a bug where matches played on official NA queue didn't count as official.
Also temporarily disables custom colors in level icons (#56)
